### PR TITLE
Makes url rewrite compatible with ingress-nginx 0.22+

### DIFF
--- a/k8s/ingress-service.yaml
+++ b/k8s/ingress-service.yaml
@@ -4,7 +4,7 @@ metadata:
   name: ingress-service
   annotations:
     kubernetes.io/ingress.class: nginx
-    nginx.ingress.kubernetes.io/rewrite-target: /
+    nginx.ingress.kubernetes.io/rewrite-target: /$1
     certmanager.k8s.io/cluster-issuer: 'letsencrypt-prod'
     nginx.ingress.kubernetes.io/ssl-redirect: 'true'
 spec:
@@ -17,22 +17,22 @@ spec:
     - host: k8s-multi.com
       http:
         paths:
-          - path: /
+          - path: /?(.*)
             backend:
               serviceName: client-cluster-ip-service
               servicePort: 3000
-          - path: /api/
+          - path: /api/?(.*)
             backend:
               serviceName: server-cluster-ip-service
               servicePort: 5000
     - host: www.k8s-multi.com
       http:
         paths:
-          - path: /
+          - path: /?(.*)
             backend:
               serviceName: client-cluster-ip-service
               servicePort: 3000
-          - path: /api/
+          - path: /api/?(.*)
             backend:
               serviceName: server-cluster-ip-service
               servicePort: 5000


### PR DESCRIPTION
Ran into issues with URL's not being rewritten correctly. - All paths were just being rewritten to root url without appending the tail portions of the path. `For example, "<host>/api/values" was just being rewritten to "<host>/" instead of "<host>/values/". `

This appears to be due to ingress-nginx introduced some changes to the rewrite annotation starting 0.22 (https://github.com/kubernetes/ingress-nginx/tree/master/docs/examples/rewrite).  With this change, everything works as expected. Tested on GKE (1.11.6-gke.2) w/ ingress-nginx version 0.22.0 (helm chart nginx-ingress-1.3.1).